### PR TITLE
chore: prepare dockerfile for multi-arch builds

### DIFF
--- a/chart/kube-ephemeral-storage-exporter/Chart.yaml
+++ b/chart/kube-ephemeral-storage-exporter/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes 
+# This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.4.0


### PR DESCRIPTION
# Multi-Architecture Dockerfile

This Dockerfile enables building for both AMD64 and ARM64 architectures using Docker BuildX.

## Key Components:

1. **Builder Stage**
   - Uses `--platform=$BUILDPLATFORM` to run on the host's native architecture
   - Sets up `$TARGETARCH` variable for cross-compilation
   - Builds binaries specifically for each target architecture

2. **Final Stage**
   - Uses `--platform=$TARGETPLATFORM` to select the correct base image
   - Copies only the architecture-appropriate binary
   - Maintains the same runtime behavior as before

## How It Works:
- When building with `--platform=linux/amd64,linux/arm64`, Docker BuildX runs the build twice
- Each build targets a different architecture
- The resulting image manifest points to the appropriate image for each platform
- Container runtimes automatically select the right image based on the host architecture

## Build Command:
```bash
docker buildx build --platform linux/amd64,linux/arm64 -t your-image:tag --push .